### PR TITLE
Update evilginx2 Dockerfile

### DIFF
--- a/evilginx2/Dockerfile
+++ b/evilginx2/Dockerfile
@@ -8,11 +8,11 @@ ENV PORTS 443 80 53/udp
 RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates make git &&\
 	rm -rf /var/lib/apt/lists/*
 
-RUN go get -u github.com/kgretzky/evilginx2
+RUN go get -u github.com/hash3liZer/evilginx2
 RUN git clone https://github.com/hash3liZer/phishlets/ /tmp/phishlets &&\
-	mv /tmp/phishlets/*.yaml /go/src/github.com/kgretzky/evilginx2/phishlets/
+	mv /tmp/phishlets/*.yaml /go/src/github.com/hash3liZer/evilginx2/phishlets/
 
-WORKDIR /go/src/github.com/kgretzky/evilginx2
+WORKDIR /go/src/github.com/hash3liZer/evilginx2
 RUN make && make install
 
 EXPOSE ${PORTS}


### PR DESCRIPTION
The official repository is not really maintained anymore (all issues removed, PRs stale, rarely responses).
The more maintained version is at https://github.com/hash3liZer/evilginx2